### PR TITLE
♻️ refactor: 맥주 조회 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha api/user/user.spec.js -w",
+    "test": "NODE_ENV=test mocha api/beer/beer.spec.js -w",
     "start": "nodemon bin/server.js",
     "commit": "cz"
   },


### PR DESCRIPTION
- 맥주 전체 데이터 조회 시 데이터 응답 형태 변경
  -  page, totalPages, totalResults, result로 응답
- 맥주 이름으로 검색 데이터 조회 시 데이터 응답 형태 변경 (이름으로 검색하는 경우, page값을 전달할 수 없으므로 totalResults와 results만 응답)
  - totalResults, result로 응답 
- 평균 별점 응답시 키 avg, number 타입으로 통일 (기존에는 rate, 혼용)
- 로그인한 유저에 대해 맥주 데이터 조회 시 보관/하트 게시물 여부를 확인할때 favorite로 통일 (기존에는 isLiked 혼용)
- 깃북 수정 완료!
